### PR TITLE
Feature/allow custom endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,3 +141,16 @@ set.sendMessageSet()
 		console.error(error);
 	})
 ```
+
+## Use behind proxy
+
+If you are behind a proxy and need to use `http` instead of `https` you can
+overwrite the default endpoints that Chatbase uses as follows:
+
+```JS
+var chatbase = require('@google/chatbase')
+	...
+	.setCreateEndpoint(); // default: https://chatbase-area120.appspot.com/api/message
+	.setCreateSetEndpoint(); // default: https://chatbase-area120.appspot.com/api/messages
+	.setUpdateEndpoint(); // default: https://chatbase-area120.appspot.com/api/message/update
+```

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ overwrite the default endpoints that Chatbase uses as follows:
 ```JS
 var chatbase = require('@google/chatbase')
 	...
-	.setCreateEndpoint(); // default: https://chatbase-area120.appspot.com/api/message
-	.setCreateSetEndpoint(); // default: https://chatbase-area120.appspot.com/api/messages
-	.setUpdateEndpoint(); // default: https://chatbase-area120.appspot.com/api/message/update
+	.setCreateEndpoint('http://custom-create-endpoint.com/api/message'); // default: https://chatbase-area120.appspot.com/api/message
+	.setCreateSetEndpoint('http://custom-create-set-endpoint.com/api/messages'); // default: https://chatbase-area120.appspot.com/api/messages
+	.setUpdateEndpoint('http://custom-update-endpoint.com/api/messages/update'); // default: https://chatbase-area120.appspot.com/api/message/update
 ```

--- a/lib/MessageFactory.js
+++ b/lib/MessageFactory.js
@@ -18,6 +18,7 @@
 
 const MessageStateWrapper = require('./MessageStateWrapper.js');
 const MessageSink = require('./MessageSink.js');
+const config = require('./config');
 
 /** 
  * Class which can produce and default select message fields to user-provided
@@ -40,6 +41,12 @@ class MessageFactory {
     this.intent = null;
     /** @property {Null|String} session_id - the custom session id (optional)*/
     this.session_id = null;
+    /** @property {String} create_endpoint - chatbase create url endpoint (optional)*/
+    this.create_endpoint = config.create_endpoint;
+    /** @property {String} create_set_endpoint - chatbase create set url endpoint  (optional)*/
+    this.create_set_endpoint = config.create_set_endpoint;
+    /** @property {String} update_endpoint - chatbase update url endpoint (optional)*/
+    this.update_endpoint = config.update_endpoint
     /** @property {Number} transport_timeout [5000] the number of Milliseconds to let a request operate for */
     this.transport_timeout = 5000;
   }
@@ -120,9 +127,39 @@ class MessageFactory {
       return this;
   }
   /**
+   * Set the custom Chatbase create endpoint url, default: https://chatbase-area120.appspot.com/api/message
+   * @function setCreateEndpoint
+   * @param {String} url - the Chatbase create endpoint url
+   * @chainable
+   */
+  setCreateEndpoint (url) {
+    this.create_endpoint = url;
+    return this;
+  }
+  /**
+   * Set the custom Chatbase create set endpoint url, default: https://chatbase-area120.appspot.com/api/messages
+   * @function setCreateSetEndpoint
+   * @param {String} url - the Chatbase create set endpoint url
+   * @chainable
+   */
+  setCreateSetEndpoint (url) {
+      this.create_set_endpoint = url;
+      return this;
+  }
+  /**
+   * Set the custom Chatbase update endpoint url, default: https://chatbase-area120.appspot.com/api/message/update
+   * @function setUpdateEndpoint
+   * @param {String} url - the Chatbase update endpoint url
+   * @chainable
+   */
+  setUpdateEndpoint (url) {
+    this.update_endpoint = url;
+    return this;
+  }
+  /**
    * Set the timeout for requests to the Chatbase API.
    * @function setClientTimeout
-   * @param {Number} customSessionId - the session id of current bot conversation
+   * @param {Number} t - the timeout for requests to the Chatbase API.
    * @chainable
    */
   setClientTimeout (t) {

--- a/lib/MessageSet.js
+++ b/lib/MessageSet.js
@@ -79,6 +79,9 @@ class MessageSet extends MessageFactory {
      */
     this.messages = [];
     this._state = new MessageLifecycleState();
+    Transport.CREATE_ENDPOINT = this.create_endpoint;
+    Transport.CREATE_SET_ENDPOINT = this.create_set_endpoint;
+    Transport.UPDATE_ENDPOINT = this.update_endpoint
   }
   /**
    * Set the API Key field for all new messages produced by this interface
@@ -158,7 +161,7 @@ class MessageSet extends MessageFactory {
   /**
    * Set the timeout for requests to the Chatbase API.
    * @function setClientTimeout
-   * @param {Number} customSessionId - the session id of current bot conversation
+   * @param {Number} t - the timeout for requests to the Chatbase API.
    * @chainable
    */
   setClientTimeout (t) {

--- a/lib/Transport.js
+++ b/lib/Transport.js
@@ -19,9 +19,10 @@
 const got = require('got');
 const merge = require('lodash.merge');
 const logger = require('./logger.js')('Transport');
-const CREATE_ENDPOINT = 'https://chatbase-area120.appspot.com/api/message';
-const CREATE_SET_ENDPOINT = 'https://chatbase-area120.appspot.com/api/messages';
-const UPDATE_ENDPOINT = 'https://chatbase-area120.appspot.com/api/message/update';
+const config = require('./config.js');
+const CREATE_ENDPOINT = config.create_endpoint;
+const CREATE_SET_ENDPOINT = config.create_set_endpoint;
+const UPDATE_ENDPOINT = config.update_endpoint;
 
 /**
  * Transport class providing wrapped net methods which provide basic request

--- a/lib/config.js
+++ b/lib/config.js
@@ -1,0 +1,24 @@
+const convict = require('convict');
+
+const config = convict({
+  create_endpoint: {
+      doc: "Chatbase create endpoint url.",
+      format: String,
+      default: 'https://chatbase-area120.appspot.com/api/message'
+  },
+  create_set_endpoint: {
+      doc: "Chatbase create set endpoint url.",
+      format: String,
+      default: 'https://chatbase-area120.appspot.com/api/messages'
+  },
+  update_endpoint: {
+      doc: "Chatbase update endpoint url.",
+      format: String,
+      default: 'https://chatbase-area120.appspot.com/api/message/update'
+  }
+});
+
+config.validate({ allowed: "strict" });
+
+// Make config accessible as JS object
+module.exports = config.getProperties();

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "nyc": "^10.1.2"
   },
   "dependencies": {
+    "convict": "^5.2.0",
     "debug": "^2.6.0",
     "got": "^6.7.1",
     "lodash.every": "^4.6.0",


### PR DESCRIPTION
# Summary

This PR:

- Refactors the hardcoded URLs in `lib/Transport.js` to a convict config
- Adds functionality to overwrite these urls if needed (for example if you use a reverse-proxy)

# Usage

If you are behind a proxy and need to use `http` instead of `https` you can
overwrite the default endpoints that Chatbase uses as follows:

```JS
var chatbase = require('@google/chatbase')
	...
	.setCreateEndpoint('http://custom-create-endpoint.com/api/message'); // default: https://chatbase-area120.appspot.com/api/message
	.setCreateSetEndpoint('http://custom-create-set-endpoint.com/api/messages'); // default: https://chatbase-area120.appspot.com/api/messages
	.setUpdateEndpoint('http://custom-update-endpoint.com/api/messages/update'); // default: https://chatbase-area120.appspot.com/api/message/update
```

# Why

The current URLs are hardcoded in `lib/transport.js` and there is no easy way of changing them in the current node package, making it difficult to use Chatbase behind a proxy which doesn't allow, for example, `https` connections.